### PR TITLE
fix: Correct `setCoordinates` method in `setError` callback

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -56,7 +56,7 @@ const useGeolocation = ({enableHighAccuracy, maximumAge, timeout} = {}, callback
 
     const setError = error => {
       if (!didCancel) {
-        updateCoordinates({
+        setCoordinates({
           accuracy: null,
           altitude: null,
           altitudeAccuracy: null,


### PR DESCRIPTION
The callback `setError()` should have directly updated the `coordinates` state, instead of calling `updateCoordinates()`. With this fix, the errors can now be read properly from the hook.