### PR TITLE
Add `enable` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ const ComponentWithGeolocation = () => {
 };
 ```
 
+### Disabling until the user has opted in
+
+You can pass `false` as the third argument to prevent geolocation.
+
+```jsx
+const geolocation = useGeolocation({}, () => {}, false);
+```
+
 ### Using `PositionOptions`
 
 [There is a way](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation_API#Fine_tuning_response) to use `PositionOptions` to fine tune response coming from `watchPosition` of the Geolocation API.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -7,6 +7,7 @@ declare module "react-hook-geolocation" {
 
   export default function useGeolocation(
     positionOptions?: PositionOptions,
-    callback?: (geolocation: EnrichedGeolocationCoordinates) => void
+    callback?: (geolocation: EnrichedGeolocationCoordinates) => void,
+    enable?: boolean
   ): EnrichedGeolocationCoordinates;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,8 @@ import { useEffect, useState, useCallback } from "react";
 
 const useGeolocation = (
   { enableHighAccuracy, maximumAge, timeout } = {},
-  callback
+  callback,
+  enable = true
 ) => {
   const [coordinates, setCoordinates] = useState({
     accuracy: null,
@@ -72,6 +73,8 @@ const useGeolocation = (
   }, []);
 
   useEffect(() => {
+    if (!enable) return;
+
     let watchId;
 
     if (navigator.geolocation) {
@@ -93,6 +96,7 @@ const useGeolocation = (
       }
     };
   }, [
+    enable,
     callback,
     enableHighAccuracy,
     maximumAge,

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -24,10 +24,44 @@ const errorHandler = (data) => (_, onError) => {
 };
 
 describe("useGeolocation", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
   describe("when geolocation data is available", () => {
-    beforeEach(() => {
-      mockCallback.mockReset();
-      mockClearWatch.mockReset();
+    it("does nothing if the enable switch is false", () => {
+      const mockCoordinates = {
+        latitude: 12.3456789,
+        longitude: 34.5678912,
+        altitude: null,
+        accuracy: 12.345,
+        altitudeAccuracy: null,
+        heading: null,
+        speed: null,
+      };
+      mockGetCurrentPosition.mockImplementationOnce(
+        successHandler({ coords: mockCoordinates })
+      );
+
+      const { result } = renderHook(() => useGeolocation({}, mockCallback, false));
+
+      expect(result.current).toStrictEqual({
+        latitude: null,
+        longitude: null,
+        altitude: null,
+        accuracy: null,
+        altitudeAccuracy: null,
+        heading: null,
+        speed: null,
+        timestamp: null,
+        error: null,
+      });
+
+      requestAnimationFrame(() => {
+        expect(mockGetCurrentPosition).notToHaveBeenCalled();
+        expect(mockWatchPosition).notToHaveBeenCalled();
+        expect(mockCallback).notToHaveBeenCalled();
+      });
     });
 
     it("reads initial geolocation", () => {


### PR DESCRIPTION
An `enable` option is added as a new third argument, which defaults to `true`. It can be set to `false` to disable geolocation. The idea is that the option can be flipped to `true` once the user has indicated that they want to be geolocated.

This means the hook can be made conditional without violating the rules of hooks and without a conditional nested component which would need to pass its data back up the tree.

Closes #51

---

Before this changeset, the first argument is a `PositionOptions` object and the second is a callback.

I considered a few ways to add this new `enable` option:

- Should it be a third argument? (non-breaking)
- Or extend `PositionOptions`? (probably non-breaking)
- Or make it the first argument and bump the existing ones to 2 and 3 (breaking)
- Or perhaps change the structure completely to an options object, such as

    ```ts
    interface UseGeolocationOptions {
      enable?: boolean;
      positionOptions?: PositionOptions;
      callback?: (geolocation: EnrichedGeolocationCoordinates) => void;
    }

    function useGeolocation(options?: UseGeolocationOptions) ...
    ```

    (breaking, unless we add extra code to check for legacy options style)

I went with the first option since it is simplest and non-breaking.

You might consider changing to the scheme in the 4th option or similar in a future major release -- it'd be tidier and more developer-friendly IMO.

---

After I wrote my test, I found that another test (specifically "useGeolocation when geolocation data is not available handles initial error") broke. This is because a particular mock was left with an implementation after my test which intentionally was not firing, and this mock was not reset before that other test was run, and that other test expected it not to be mocked. So I removed the specific resets, and added a blanket reset all mocks after each test across the whole suite.